### PR TITLE
Changed search of user to match exact username only

### DIFF
--- a/like_my_gf.py
+++ b/like_my_gf.py
@@ -43,13 +43,18 @@ def get_auth():
 
 def auth_request():
     api = InstagramAPI(access_token=OTHER['access_token'])
-    target_ids = api.user_search(OTHER['target'], 1)
+    target_ids = api.user_search(OTHER['target'])
 
-    if len(target_ids) > 1:
-        logging.error('Found mutiple users, please check username')
-        return
+    target_id = None
+    for search_hit in target_ids:
+        if search_hit.username == OTHER['target']:
+            target_id = search_hit.id
+            break
 
-    target_id = target_ids[0].id
+    if target_id == None:
+        logging.error('Did not find user, please check username')
+        return []
+
     my_name   = api.user().username
     logging.debug('Starting check recent media')
     recent_media, url = api.user_recent_media(user_id=target_id, count = 20)


### PR DESCRIPTION
Instead of limiting the search to one user and hoping that will be the correct on (spoiler: it was wrong for me), I made it search for the username and check matching username.

**Example:**
Entering the username `123` (a user has that exact username) the first match is not the correct one (a user with the username `123.amazingvideos`).

I am no python programmer so this pull request is more a suggestion but I wanted to do more than add an issue. :)

Also added `[]` to the return after logging the error, since without it I got `TypeError: object of type 'NoneType' has no len()`
